### PR TITLE
configファイルを生成しない場合に発生するエラー回避

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ If a factory of table exists, it will be skipped and continue to generate factor
 ```bash
 php artisan generate:factory  --all
 ```
+#### If you cannot use configuration after publishing
+clear cache with below command.
+`php artisan config:clear`
 
 ## License
 This project is released under MIT License. See [MIT License](LICENSE)

--- a/src/Commands/GenerateFactory.php
+++ b/src/Commands/GenerateFactory.php
@@ -188,7 +188,7 @@ class GenerateFactory extends GeneratorCommand
         $ignoredColumns = $this->config->get('factory-generator.ignored_columns');
 
         foreach ($columns as $column) {
-            if (in_array($column, $ignoredColumns)) {
+            if ($ignoredColumns && in_array($column, $ignoredColumns)) {
                 continue;
             }
 


### PR DESCRIPTION
laravel6.6で動作確認しました。
composerでインストールを行い、コンフィギュレーションファイルを生成せず --allオプションを使用しファクトリを生成しようとした場合に発生するエラーを回避しました。
（コンフィグレーションは絶対作成するという前提であったのであればすみません。。。）
